### PR TITLE
タイマー終了後にバイブレーションをさせる

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,8 +56,8 @@ dependencies {
     implementation "androidx.navigation:navigation-compose:$nav_version"
 
     // Hilt
-    implementation "com.google.dagger:hilt-android:2.38.1"
-    kapt "com.google.dagger:hilt-compiler:2.40.1"
+    implementation "com.google.dagger:hilt-android:2.43.2"
+    kapt "com.google.dagger:hilt-compiler:2.43.2"
     implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
 
     // Tracing

--- a/app/src/main/java/com/rnk0085/android/takenoko/MainActivity.kt
+++ b/app/src/main/java/com/rnk0085/android/takenoko/MainActivity.kt
@@ -40,22 +40,6 @@ class MainActivity : ComponentActivity() {
             -1
         )
 
-        // TODO: 期待通りの動作が出来たら削除する
-        // バイブレーション出来るか確認
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            Log.d("debug", "Build.VERSION_CODES.S")
-            val vibratorManager = applicationContext.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
-            val combinedVibration = CombinedVibration.createParallel(vibrationEffect)
-            vibratorManager.vibrate(combinedVibration)
-        } else {
-            Log.d("debug", "Not Build.VERSION_CODES.S")
-            val vibrator = applicationContext.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-            vibrator.vibrate(vibrationEffect)
-        }
-
-        Log.d("debug", "MainActivity")
-
-        // TODO: タイマーが終了した時にバイブレーションするようにしたい
         lifecycleScope.launch {
             viewModel.uiState
                 .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
@@ -70,21 +54,6 @@ class MainActivity : ComponentActivity() {
                             Log.d("debug", "Not Build.VERSION_CODES.S")
                             val vibrator = applicationContext.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
                             vibrator.vibrate(vibrationEffect)
-                        }
-                    }
-
-                    when (uiState.timerState) {
-                        TimerState.FINISHED -> {
-                            Log.d("debug", "FINISHED")
-                        }
-                        TimerState.INITIAL -> {
-                            Log.d("debug", "INITIAL")
-                        }
-                        TimerState.RUNNING -> {
-                            Log.d("debug", "RUNNING")
-                        }
-                        TimerState.PAUSED -> {
-                            Log.d("debug", "PAUSED")
                         }
                     }
                 }

--- a/app/src/main/java/com/rnk0085/android/takenoko/MainActivity.kt
+++ b/app/src/main/java/com/rnk0085/android/takenoko/MainActivity.kt
@@ -31,7 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        Log.d("debug", "MainActivity")
+        Log.d("debug", "MainActivity - TimerUiState: ${viewModel.uiState}")
 
         // TODO: 振動する回数を決める
         val vibrationEffect = VibrationEffect.createWaveform(

--- a/app/src/main/java/com/rnk0085/android/takenoko/MainActivity.kt
+++ b/app/src/main/java/com/rnk0085/android/takenoko/MainActivity.kt
@@ -40,6 +40,8 @@ class MainActivity : ComponentActivity() {
             -1
         )
 
+        // TODO: アプリがバックグラウンドにある場合でもバイブレーションするようにしたい
+        // バックグラウンドにいった瞬間 Flow の collect が止まるのが原因っぽい
         lifecycleScope.launch {
             viewModel.uiState
                 .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)

--- a/app/src/main/java/com/rnk0085/android/takenoko/ui/navigation/TimerNavigation.kt
+++ b/app/src/main/java/com/rnk0085/android/takenoko/ui/navigation/TimerNavigation.kt
@@ -1,5 +1,7 @@
 package com.rnk0085.android.takenoko.ui.navigation
 
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -13,7 +15,7 @@ object TimerDestination : TakenokoNavigationDestination {
 fun NavGraphBuilder.timerGraph() {
     composable(route = TimerDestination.route) {
         TimerScreen(
-            viewModel = hiltViewModel()
+            viewModel = hiltViewModel(viewModelStoreOwner = LocalContext.current as ComponentActivity)
         )
     }
 }

--- a/app/src/main/java/com/rnk0085/android/takenoko/ui/screen/timer/TimerScreen.kt
+++ b/app/src/main/java/com/rnk0085/android/takenoko/ui/screen/timer/TimerScreen.kt
@@ -1,5 +1,6 @@
 package com.rnk0085.android.takenoko.ui.screen.timer
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
@@ -18,6 +19,7 @@ import java.time.Duration
 fun TimerScreen(
     viewModel: TimerViewModel
 ) {
+    Log.d("debug", "TimerScreen - TimerUiState: ${viewModel.uiState}")
     val uiState: TimerUiState by viewModel.uiState.collectAsState()
     TimerScreen(
         uiState = uiState,

--- a/app/src/main/java/com/rnk0085/android/takenoko/ui/screen/timer/TimerScreen.kt
+++ b/app/src/main/java/com/rnk0085/android/takenoko/ui/screen/timer/TimerScreen.kt
@@ -3,6 +3,7 @@ package com.rnk0085.android.takenoko.ui.screen.timer
 import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -26,7 +27,8 @@ fun TimerScreen(
         onSetTimer = viewModel::setTimer,
         onRestartClick = viewModel::startTimer,
         onPauseClick = viewModel::pauseTimer,
-        cancelTimer = viewModel::cancelTimer
+        cancelTimer = viewModel::cancelTimer,
+        recordStudyTime = viewModel::recordStudyTime
     )
 }
 
@@ -36,7 +38,8 @@ private fun TimerScreen(
     onSetTimer: (Duration) -> Unit,
     onRestartClick: () -> Unit,
     onPauseClick: () -> Unit,
-    cancelTimer: () -> Unit
+    cancelTimer: () -> Unit,
+    recordStudyTime: () -> Unit
 ) {
     Box {
         // TODO: 自動的に切り替えを行う
@@ -49,7 +52,10 @@ private fun TimerScreen(
                 )
             }
             TimerState.FINISHED -> {
-                Text(text = "FINISHED")
+                // TODO: タイマー終了後の画面を作成する
+                Button(onClick = recordStudyTime) {
+                    Text(text = "FINISHED")
+                }
             }
             else -> {
                 // RUNNING & PAUSED
@@ -76,7 +82,8 @@ private fun TimerScreenPreview() {
             onSetTimer = {},
             onRestartClick = {},
             onPauseClick = {},
-            cancelTimer = {}
+            cancelTimer = {},
+            recordStudyTime = {}
         )
     }
 }

--- a/app/src/main/java/com/rnk0085/android/takenoko/ui/screen/timer/TimerViewModel.kt
+++ b/app/src/main/java/com/rnk0085/android/takenoko/ui/screen/timer/TimerViewModel.kt
@@ -96,6 +96,15 @@ class TimerViewModel @Inject constructor() : ViewModel() {
         Log.d("debug", "cancelTimer")
     }
 
+    // TODO: 勉強時間を記録する処理を書く
+    fun recordStudyTime() {
+        _uiState.update {
+            it.copy(
+                timerState = TimerState.INITIAL
+            )
+        }
+    }
+
     companion object {
         private const val COUNTDOWN_INTERVAL: Long = 1000L
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.40.1'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.43.2'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {


### PR DESCRIPTION
## 概要

- 同じ `TimerViewModel` を参照するようにし、タイマー終了後にバイブレーションが起きるようになった

### 関連Issue

Close #6 タイマー処理を作成する
Close #19 タイマー終了後にバイブレーションが出来ていない

一応これらのIssueは出来ていると見なして閉じる。新たに分かったことは、別にIssueを立てて対応する。

## やったこと

- `hiltViewModel` に `viewModelStoreOwner` を設定
  - [Sharing viewModel within Jetpack Compose Navigation](https://stackoverflow.com/questions/68548488/sharing-viewmodel-within-jetpack-compose-navigation) の辺りを参考に

``` kotlin
TimerScreen(
    viewModel = hiltViewModel(viewModelStoreOwner = LocalContext.current as ComponentActivity)
)
```

``` kotlin
@Composable
inline fun <reified VM : ViewModel> hiltViewModel(
    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
    }
): VM {
    val factory = createHiltViewModelFactory(viewModelStoreOwner)
    return viewModel(viewModelStoreOwner, factory = factory)
}
```

## スクリーンショット

実機で確認するしかない…

## その他

`CountDownTimer` では無理がある可能性が高い